### PR TITLE
param 定义 body json 参数验证

### DIFF
--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -6,6 +6,9 @@ describe('basic', function () {
     test('200', async function () {
       const flow = new Flow(
         {
+          resource: {
+            handler: () => -1
+          },
           triggers: {
             http: {
               handler,
@@ -30,6 +33,9 @@ describe('basic', function () {
     test('500', async function () {
       const flow = new Flow(
         {
+          resource: {
+            handler: () => -1
+          },
           triggers: {
             http: {
               handler,
@@ -51,6 +57,9 @@ describe('basic', function () {
   test('async mode', async function () {
     const flow = new Flow(
       {
+        resource: {
+          handler: () => -1
+        },
         mode: 'async',
         triggers: {
           http: {

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -6,6 +6,9 @@ describe('helpers', function () {
     test('add', async function () {
       const flow = new Flow(
         {
+          resource: {
+            handler: () => -1
+          },
           triggers: {
             http: {
               handler,
@@ -25,6 +28,9 @@ describe('helpers', function () {
     test('delete', async function () {
       const flow = new Flow(
         {
+          resource: {
+            handler: () => -1
+          },
           triggers: {
             http: {
               handler,
@@ -45,6 +51,9 @@ describe('helpers', function () {
   test('setStatusCode', async function () {
     const flow = new Flow(
       {
+        resource: {
+          handler: () => -1
+        },
         triggers: {
           http: {
             handler,
@@ -65,6 +74,9 @@ describe('helpers', function () {
     test('string', async function () {
       const flow = new Flow(
         {
+          resource: {
+            handler: () => -1
+          },
           triggers: {
             http: {
               handler,
@@ -84,6 +96,9 @@ describe('helpers', function () {
     test('object', async function () {
       const flow = new Flow(
         {
+          resource: {
+            handler: () => -1
+          },
           triggers: {
             http: {
               handler,

--- a/src/__tests__/method.test.ts
+++ b/src/__tests__/method.test.ts
@@ -4,6 +4,9 @@ import { handler } from '../index';
 describe('method', function () {
   const flow = new Flow(
     {
+      resource: {
+        handler: () => -1
+      },
       triggers: {
         http: {
           handler,

--- a/src/__tests__/param.test.ts
+++ b/src/__tests__/param.test.ts
@@ -4,13 +4,26 @@ import { handler } from '../index';
 describe('param', function () {
   const flow = new Flow(
     {
+      resource: {
+        handler: () => -1
+      },
       triggers: {
         http: {
           handler,
           param: {
             key: {
               required: true,
+              type: 'number'
             },
+            key1: {
+              type: 'string'
+            },
+            key2: {
+              verified: (a: number) => {
+                return a + 1 > 2;
+              },
+              type: 'number'
+            }
           },
         },
       },
@@ -30,6 +43,36 @@ describe('param', function () {
 
     expect(res.statusCode).toEqual(200);
     expect(res.body).toEqual('{"data":{"key":1}}');
+  });
+
+  test('correct', async function () {
+    const res = await trigger({
+      body: '{"key":1, "key1": "1", "key2":1}',
+      header: { 'Content-Type': 'application/json; charset=UTF-8' },
+    }, {});
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual('{"data":{"key":1,"key1":"1","key2":1}}');
+  });
+
+  test('type error', async function () {
+    const res = await trigger({
+      body: '{"key":1, "key2": 3}',
+      header: { 'Content-Type': 'application/json; charset=UTF-8' },
+    }, {});
+
+    expect(res.statusCode).toEqual(500);
+    expect(res.body).toEqual('{"error":{"message":"key2 verification failed"}}');
+  });
+
+  test('type error', async function () {
+    const res = await trigger({
+      body: '{"key":"1"}',
+      header: { 'Content-Type': 'application/json; charset=UTF-8' },
+    }, {});
+
+    expect(res.statusCode).toEqual(500);
+    expect(res.body).toEqual('{"error":{"message":"key type error"}}');
   });
 
   test('error', async function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,18 +100,9 @@ export async function handler (flow: Flow, trigger: any, data: {
   if (trigger.param) {
     for (const key in trigger.param) {
       if (trigger.param.hasOwnProperty(key)) {
-        const config: {
-          required?: boolean;
-          type?: string;
-          handler?: (value: any) => any;
-          internal: boolean;
-          error: string;
-          [key: string]: any;
-        } = trigger.param[key as string].verifiy;
-
         // 只允许从 body 中读取参数
         // 递归校验
-        verification(input.body, config, key, trigger.param[key as string]);
+        verification(input.body, trigger.param[key as string].verifiy, key, trigger.param[key as string]);
 
         if (output) {
           break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,8 @@ export async function handler (flow: Flow, trigger: any, data: {
         const config: {
           position?: 'header' | 'query' | 'body';
           required?: boolean;
+          type?: string;
+          verified?: (value: any) => any;
           [key: string]: any;
         } = trigger.param[key as string];
 
@@ -75,6 +77,18 @@ export async function handler (flow: Flow, trigger: any, data: {
           )
         ) {
           output = Error(`${key} required`);
+          break;
+        }
+
+        // 输入项类型校验
+        if (config.type && input[config.position][key as string] && typeof input[config.position][key as string] !== config.type) {
+          output = Error(`${key} type error`);
+          break;
+        }
+
+        // 自定义校验
+        if (config.verified && input[config.position][key as string] && config.verified!(input[config.position][key as string])) {
+          output = Error(`${key} verification failed`);
           break;
         }
 


### PR DESCRIPTION
注意：仅接收在 param 中定义的参数，仅读取由 body 传递的参数
允许 param 传入自定义 verifiy

verifiy 支持字段
``` 
verifiy: {
  required: 是否必填
  type: 传入值类型, 支持基础类型
  handler: 自定义判断类型
  error: 自定义判断类型
  internal: 是否有内部层级
}
```

Example
```
param:{
  key: {
    verifiy: {
        required: true,
        type: 'string'
    }
  },
  key2: {
    verifiy: {
      required: true,
      internal: true,
    }
    key3: {
      verifiy: {
        required: true
        type: 'integer'
      }
    }
  }
}
```

